### PR TITLE
refactor(*): Change repository names in source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ $ curl -X POST http://localhost:5000/api/v1/chaincode/proposals/deploy_basic \
     "channelID": "mychannel",
     "chaincodeName": "basic",
     "chaincodePackage": {
-      "repository": "github.com/satota2/fabric-opssc",
+      "repository": "github.com/hyperledger-labs/fabric-opssc",
       "pathToSourceFiles": "sample-environments/fabric-samples/asset-transfer-basic/chaincode-go",
       "commitID": "master",
       "type": "golang"

--- a/chaincode/chaincode_ops/core/chaincode_ops_test.go
+++ b/chaincode/chaincode_ops/core/chaincode_ops_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/stretchr/testify/require"
-	"github.com/satota2/fabric-opssc/chaincode/chaincode_ops/core/mocks"
+	"github.com/hyperledger-labs/fabric-opssc/chaincode/chaincode_ops/core/mocks"
 )
 
 var (

--- a/chaincode/chaincode_ops/go.mod
+++ b/chaincode/chaincode_ops/go.mod
@@ -1,4 +1,4 @@
-module github.com/satota2/fabric-opssc/chaincode/chaincode_ops
+module github.com/hyperledger-labs/fabric-opssc/chaincode/chaincode_ops
 
 go 1.14
 

--- a/chaincode/chaincode_ops/main.go
+++ b/chaincode/chaincode_ops/main.go
@@ -10,7 +10,7 @@ import (
 	"log"
 
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
-	"github.com/satota2/fabric-opssc/chaincode/chaincode_ops/core"
+	"github.com/hyperledger-labs/fabric-opssc/chaincode/chaincode_ops/core"
 )
 
 func main() {

--- a/chaincode/channel_ops/chaincode/channel_ops_test.go
+++ b/chaincode/channel_ops/chaincode/channel_ops_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/ledger/queryresult"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/stretchr/testify/require"
-	"github.com/satota2/fabric-opssc/chaincode/channel_ops/chaincode/mocks"
+	"github.com/hyperledger-labs/fabric-opssc/chaincode/channel_ops/chaincode/mocks"
 )
 
 var (

--- a/chaincode/channel_ops/chaincode/networkinfo_test.go
+++ b/chaincode/channel_ops/chaincode/networkinfo_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
 	"github.com/hyperledger/fabric-protos-go/ledger/queryresult"
 	"github.com/stretchr/testify/require"
-	"github.com/satota2/fabric-opssc/chaincode/channel_ops/chaincode"
-	"github.com/satota2/fabric-opssc/chaincode/channel_ops/chaincode/mocks"
+	"github.com/hyperledger-labs/fabric-opssc/chaincode/channel_ops/chaincode"
+	"github.com/hyperledger-labs/fabric-opssc/chaincode/channel_ops/chaincode/mocks"
 )
 
 //go:generate counterfeiter -o mocks/transaction.go -fake-name TransactionContext . transactionContext

--- a/chaincode/channel_ops/go.mod
+++ b/chaincode/channel_ops/go.mod
@@ -1,4 +1,4 @@
-module github.com/satota2/fabric-opssc/chaincode/channel_ops
+module github.com/hyperledger-labs/fabric-opssc/chaincode/channel_ops
 
 go 1.14
 

--- a/chaincode/channel_ops/main.go
+++ b/chaincode/channel_ops/main.go
@@ -10,7 +10,7 @@ import (
 	"log"
 
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
-	"github.com/satota2/fabric-opssc/chaincode/channel_ops/chaincode"
+	"github.com/hyperledger-labs/fabric-opssc/chaincode/channel_ops/chaincode"
 )
 
 func main() {

--- a/configtx-cli/cmd/create_channel.go
+++ b/configtx-cli/cmd/create_channel.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
-	"github.com/satota2/fabric-opssc/configtx-cli/ops"
+	"github.com/hyperledger-labs/fabric-opssc/configtx-cli/ops"
 )
 
 // CreateChannelCmd returns the cobra command for create-channel.

--- a/configtx-cli/cmd/create_envelope.go
+++ b/configtx-cli/cmd/create_envelope.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
-	"github.com/satota2/fabric-opssc/configtx-cli/ops"
+	"github.com/hyperledger-labs/fabric-opssc/configtx-cli/ops"
 )
 
 // CreateEnvelopeCmd returns the cobra command for create-envelope.

--- a/configtx-cli/cmd/multiple_ops.go
+++ b/configtx-cli/cmd/multiple_ops.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
-	"github.com/satota2/fabric-opssc/configtx-cli/ops"
+	"github.com/hyperledger-labs/fabric-opssc/configtx-cli/ops"
 )
 
 // MultipleOpsCmd returns the cobra command for execute-multiple-ops.

--- a/configtx-cli/cmd/remove_consenter.go
+++ b/configtx-cli/cmd/remove_consenter.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
-	"github.com/satota2/fabric-opssc/configtx-cli/ops"
+	"github.com/hyperledger-labs/fabric-opssc/configtx-cli/ops"
 )
 
 // RemoveConsenterCmd returns the cobra command for remove-consenter.

--- a/configtx-cli/cmd/remove_org.go
+++ b/configtx-cli/cmd/remove_org.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
-	"github.com/satota2/fabric-opssc/configtx-cli/ops"
+	"github.com/hyperledger-labs/fabric-opssc/configtx-cli/ops"
 )
 
 // RemoveOrgCmd returns the cobra command for remove-org.

--- a/configtx-cli/cmd/set_channel.go
+++ b/configtx-cli/cmd/set_channel.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
-	"github.com/satota2/fabric-opssc/configtx-cli/ops"
+	"github.com/hyperledger-labs/fabric-opssc/configtx-cli/ops"
 )
 
 // SetChannelCmd returns the cobra command for set-channel.

--- a/configtx-cli/cmd/set_consenter.go
+++ b/configtx-cli/cmd/set_consenter.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
-	"github.com/satota2/fabric-opssc/configtx-cli/ops"
+	"github.com/hyperledger-labs/fabric-opssc/configtx-cli/ops"
 )
 
 // SetConsenterCmd returns the cobra command for set-consenter.

--- a/configtx-cli/cmd/set_orderer.go
+++ b/configtx-cli/cmd/set_orderer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
-	"github.com/satota2/fabric-opssc/configtx-cli/ops"
+	"github.com/hyperledger-labs/fabric-opssc/configtx-cli/ops"
 )
 
 // SetOrdererCmd returns the cobra command for set-orderer.

--- a/configtx-cli/cmd/set_org.go
+++ b/configtx-cli/cmd/set_org.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
-	"github.com/satota2/fabric-opssc/configtx-cli/ops"
+	"github.com/hyperledger-labs/fabric-opssc/configtx-cli/ops"
 )
 
 // SetOrgCmd returns the cobra command for set-org.

--- a/configtx-cli/cmd/sign.go
+++ b/configtx-cli/cmd/sign.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
-	"github.com/satota2/fabric-opssc/configtx-cli/ops"
+	"github.com/hyperledger-labs/fabric-opssc/configtx-cli/ops"
 )
 
 // SignCmd returns the cobra command for sign.

--- a/configtx-cli/go.mod
+++ b/configtx-cli/go.mod
@@ -1,4 +1,4 @@
-module github.com/satota2/fabric-opssc/configtx-cli
+module github.com/hyperledger-labs/fabric-opssc/configtx-cli
 
 go 1.14
 

--- a/configtx-cli/main.go
+++ b/configtx-cli/main.go
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 package main
 
-import "github.com/satota2/fabric-opssc/configtx-cli/cmd"
+import "github.com/hyperledger-labs/fabric-opssc/configtx-cli/cmd"
 
 func main() {
 	cmd.Execute()

--- a/integration/steps/chaincode-ops.steps.ts
+++ b/integration/steps/chaincode-ops.steps.ts
@@ -30,7 +30,7 @@ export class ChaincodeOpsSteps extends BaseStepClass {
 
   @when(/(.+) requests a proposal to deploy the chaincode \(name: (.+), seq: (\d+), channel: (.+)\) based on basic (golang|javascript|typescript) template via opssc-api-server/)
   public async requestChaincodeDeploymentProposal(org: string, ccName: string, sequence: number, channelID: string, lang: string) {
-    const repository = process.env.IT_REMOTE_CC_REPO || 'github.com/satota2/fabric-opssc';
+    const repository = process.env.IT_REMOTE_CC_REPO || 'github.com/hyperledger-labs/fabric-opssc';
     const commitID = process.env.IT_REMOTE_COMMIT_ID || 'master';
     let pathToSourceFiles;
     switch (lang) {

--- a/opssc-api-server/APISpecification.md
+++ b/opssc-api-server/APISpecification.md
@@ -56,7 +56,7 @@
       "channelID": "mychannel",
       "chaincodeName": "basic",
       "chaincodePackage": {
-        "repository": "github.com/satota2/fabric-opssc",
+        "repository": "github.com/hyperledger-labs/fabric-opssc",
         "pathToSourceFiles": "sample-environments/fabric-samples/asset-transfer-basic/chaincode-go",
         "commitID": "master",
         "type": "golang"


### PR DESCRIPTION
This patch changes repository names in source code from "github.com/satota2/fabric-opssc" to "github.com/hyperledger-labs/fabric-opssc".

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>