### PR TITLE
feat(sample): Add docs and scripts for adding new org to sample env

### DIFF
--- a/sample-environments/fabric-samples/test-network/create-org4-artifacts-for-test-network.sh
+++ b/sample-environments/fabric-samples/test-network/create-org4-artifacts-for-test-network.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright 2020-2021 Hitachi America, Ltd.
+#
+set -e
+
+if [ "$FABRIC_CA_VERSION" == "" ]; then
+  echo 'FABRIC_CA_VERSION should be set. (e.g., 1.4.9)'
+  exit 1
+fi
+
+ORG_INDEX=4
+ORG=org${ORG_INDEX}
+
+CA_PORT=13054
+PEER1_PORT=13051
+ORDERER_PORT=13050
+
+IMAGE_TAG=${FABRIC_CA_VERSION} docker-compose -f docker/docker-compose-ca-${ORG}.yaml up -d
+sleep 3
+
+./registerEnroll.sh ${ORG_INDEX} ca-${ORG} ${CA_PORT} ${PEER1_PORT} ${ORDERER_PORT}
+
+echo ""
+echo "[CA Certificate for ${ORG}]"
+
+cat organizations/peerOrganizations/${ORG}.example.com/msp/cacerts/localhost-${CA_PORT}-ca-${ORG}.pem
+
+echo ""
+echo "[TLS CA Certificate for ${ORG}]"
+
+cat organizations/peerOrganizations/${ORG}.example.com/msp/tlscacerts/ca.crt
+
+echo ""
+echo "[Client/Server Certificate for ${ORG} Consenter]"
+
+cat organizations/peerOrganizations/${ORG}.example.com/orderers/orderer0.${ORG}.example.com/tls/server.crt

--- a/sample-environments/fabric-samples/test-network/launch-org4-nodes-for-test-network.sh
+++ b/sample-environments/fabric-samples/test-network/launch-org4-nodes-for-test-network.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright 2020-2021 Hitachi America, Ltd.
+#
+set -e
+
+if [ "$FABRIC_VERSION" == "" ]; then
+  echo 'FABRIC_VERSION should be set. (e.g., 2.3.0)'
+  exit 1
+fi
+
+ORG_INDEX=4
+ORG=org${ORG_INDEX}
+
+if [ "$1" == "" ]; then
+  # For test, fetch system config block via org1's nodes.
+  ./fetchSystemConfigBlock.sh 1
+else
+  echo ""
+  echo "[Save the specified system config block as a local file]"
+  CONFIG_BLOCK_BASE64=$1
+  echo "${CONFIG_BLOCK_BASE64}" | base64 -d > system-genesis-block/updated_genesis.block
+fi
+
+echo ""
+echo "[Launch orderers and peers for ${ORG}]"
+IMAGE_TAG=${FABRIC_VERSION} docker-compose -f docker/docker-compose-orderer-${ORG}.yaml up -d
+IMAGE_TAG=${FABRIC_VERSION} docker-compose -f docker/docker-compose-peer-${ORG}.yaml up -d
+
+echo ""
+
+echo ""
+echo "[Launch agents and clients for ${ORG}]"
+docker-compose -f docker/docker-compose-opssc-api-servers-${ORG}.yaml up -d
+docker-compose -f docker/docker-compose-opssc-agents-${ORG}.yaml up -d


### PR DESCRIPTION
This patch adds documents of adding a new organization named Org4MSP to the
running test network. To make the procedure easier, the patch adds the
utility scripts to create keys/certs for the org and launch nodes for the org.

Signed-off-by: Tatsuya Sato <Tatsuya.Sato@hal.hitachi.com>