### PR TITLE
Add voting config option

### DIFF
--- a/integration/features/chaincode-ops-on-docker.feature
+++ b/integration/features/chaincode-ops-on-docker.feature
@@ -47,16 +47,21 @@ Feature: Chaincode ops on docker-based Fabric network
     And chaincode (name: private, seq: 1, channel: mychannel) should be committed over the fabric network
     And chaincode (name: private, channel: mychannel) should be set the collections for private template
 
+    # Set max malicious orgs in votes to 0
+    When consortium sets max malicious orgs in votes (number: 0)
+
     # Chaincode update
     When org1 requests a proposal to deploy the chaincode (name: basic, seq: 2, channel: mychannel) based on basic golang template via opssc-api-server
-    And org2 votes for the proposal for chaincode (name: basic, seq: 2, channel: mychannel) with opssc-api-server
-    Then the proposal for chaincode (name: basic, seq: 2, channel: mychannel) should be voted (with agreed) by 2 or more orgs
+    Then the proposal for chaincode (name: basic, seq: 2, channel: mychannel) should be voted (with agreed) by 1 or more orgs
     And the proposal for chaincode (name: basic, seq: 2, channel: mychannel) should be acknowledged (with success) by 2 or more orgs
     And the proposal for chaincode (name: basic, seq: 2, channel: mychannel) should be committed (with success) by 1 or more orgs
     And the proposal status for chaincode (name: basic, seq: 2, channel: mychannel) should be committed
     And chaincode (name: basic, seq: 2, channel: mychannel) should be committed over the fabric network
     And chaincode (name: basic, channel: mychannel) based on basic should be able to register the asset (ID: asset102) by invoking CreateAsset func
     And chaincode (name: basic, channel: mychannel) based on basic golang should be able to get the asset (ID: asset102) by querying ReadAsset func
+
+    # Unset max malicious orgs in votes
+    When consortium unsets max malicious orgs in votes
 
     # Chaincode update for one not yet deployed
     When org1 requests a proposal to deploy the chaincode (name: basic2, seq: 2, channel: mychannel) based on basic golang template via opssc-api-server

--- a/integration/steps/chaincode-ops.steps.ts
+++ b/integration/steps/chaincode-ops.steps.ts
@@ -25,8 +25,11 @@ const TaskTypeFuncs = {
   }
 };
 
+
 @binding()
 export class ChaincodeOpsSteps extends BaseStepClass {
+
+  protected static CC_NAME = 'chaincode_ops';
 
   @when(/(.+) requests a proposal to deploy the chaincode \(name: (.+), seq: (\d+), channel: (.+)\) based on (basic|private) (golang|javascript|typescript) template via opssc-api-server/)
   public async requestChaincodeDeploymentProposal(org: string, ccName: string, sequence: number, channelID: string, ccTemplate: string, lang: string) {
@@ -340,6 +343,35 @@ export class ChaincodeOpsSteps extends BaseStepClass {
       }
     );
     expect(response.status).to.equals(200);
+  }
+
+  @when(/consortium sets max malicious orgs in votes \(number: (\d+)\)/)
+  public async setMaxMaliciousOrgsInVotes(number: number) {
+    const status = await this.invokeChaincodeOpsFunc('SetMaxMaliciousOrgsInVotes', [`${number}`]);
+    expect(status).to.equals(200);
+  }
+
+  @when(/consortium unsets max malicious orgs in votes/)
+  public async unsetMaxMaliciousOrgsInVotes() {
+    const status = await this.invokeChaincodeOpsFunc('UnsetMaxMaliciousOrgsInVotes', []);
+    expect(status).to.equals(200);
+  }
+
+  private async invokeChaincodeOpsFunc(funcName: string, args: string[]): Promise<number> {
+    const response = await axios.post(`${this.getAPIEndpoint()}/api/v1/utils/invokeTransaction`,
+      {
+        channelID: ChaincodeOpsSteps.OPS_CHANNEL,
+        ccName: ChaincodeOpsSteps.CC_NAME,
+        func: funcName,
+        args: args,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+    return response.status;
   }
 
   @then(/(.+) fails to approve the proposal for chaincode \(name: (.+), seq: (\d+), channel: (.+)\) with an error \((.+)\)/)

--- a/integration/utils/base-step-class.ts
+++ b/integration/utils/base-step-class.ts
@@ -47,6 +47,7 @@ export default class BaseStepClass {
   }
 
   protected static TEST_NETWORK_PATH = '../sample-environments/fabric-samples/test-network';
+  protected static OPS_CHANNEL = 'ops-channel';
 
   protected static RETRY = 15;
   protected static SUFFIX = moment().format('MMDD_HHmmss');


### PR DESCRIPTION
This patch adds a voting configuration option for chaincode_ops.
This allows OpsSC users to configure the maximum number of malicious organizations (`f`) in the voting process.

- If the option is set, 2f + 1 is required to judge a proposal get `Approved`.
- If the option is not set, a majority of all participating organizations is required to judge a proposal get `Approved`.