### PR TITLE
fix(agent): Fix a bug when handling a proposal not using the next sequence

### DIFF
--- a/common/src/lib/sig_policy_syntax_lib.ts
+++ b/common/src/lib/sig_policy_syntax_lib.ts
@@ -152,7 +152,7 @@ function conformPolicySyntax(input: string | MixedPolicySyntax) {
     // error already logged
     return null;
   } else {
-    logger.info('[protobuf-handler] built signature policy object using Fabric syntax:', JSON.stringify(policy_obj, null, 2));
+    logger.debug('[protobuf-handler] built signature policy object using Fabric syntax: %s', JSON.stringify(policy_obj, null, 2));
     return policy_obj;
   }
 
@@ -249,7 +249,7 @@ function conformPolicySyntax(input: string | MixedPolicySyntax) {
     const msp = onWord;
     if (msp && typeof identityPositionMap[msp] !== 'undefined') {			// if its in the map, its definitely a msp word
       ruleObj.n_out_of.rules.push({ signed_by: identityPositionMap[msp] });	// the value of signed_by its the array position of this msp
-      logger.debug('[protobuf-handler] added msp to inner ruleObj:', JSON.stringify(ruleObj, null, 2));
+      logger.debug('[protobuf-handler] added msp to inner ruleObj: %s', JSON.stringify(ruleObj, null, 2));
       return build_rules_from_cli(str, words.slice(1), ruleObj, ++depth);
     }
 
@@ -309,7 +309,7 @@ function conformPolicySyntax(input: string | MixedPolicySyntax) {
       } else {
         ruleObj.n_out_of.rules.push(ruleObjInner);							// add rules to PREV command
       }
-      logger.debug('[protobuf-handler] finished inner ruleObj:', JSON.stringify(ruleObj, null, 2), parsed.resume);
+      logger.debug('[protobuf-handler] finished inner ruleObj: %s, %s', JSON.stringify(ruleObj, null, 2), parsed.resume);
 
       // see if we need to resume a past command, else we are done and can return this rule object
       if (parsed.resume) {

--- a/opssc-agent/src/package-lock.json
+++ b/opssc-agent/src/package-lock.json
@@ -2429,7 +2429,8 @@
         },
         "color-string": {
           "version": "1.5.4",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
+          "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
           "requires": {
             "color-name": "^1.0.0",
             "simple-swizzle": "^0.2.2"


### PR DESCRIPTION
Normally, if a proposal uses an incorrect sequence number, there is no problem
because committing the chaincode definition will fail.

However, in the case of a proposal with the current sequence number and a new
chaincode source code, the approval process will update the chaincode package
in the sequence unexpectedly. Furthermore, in the case of using an earlier
sequence number, resources are wasted due to installing the chaincode successfully.

To avoid the cases, this patch adds a process to compare the committed sequence
number with the proposed one at the top of prepareToDeploy().

Also, the PR includes some minor modifications.