### PR TITLE
Add updateChannelType() and introduce the disable channel type

### DIFF
--- a/integration/features/chaincode-ops-on-docker.feature
+++ b/integration/features/chaincode-ops-on-docker.feature
@@ -20,6 +20,11 @@ Feature: Chaincode ops on docker-based Fabric network
     Given register orgs info for mychannel (type: application) to opssc on ops-channel
 
     Given bootstrap opssc-api-servers for initial orgs
+
+    # Disabled channels are ignored by OpsSC Agents
+    Given register orgs info for invalid-channel (type: application) to opssc on ops-channel
+    Given disable invalid-channel channel on opssc via opssc-api-server
+
     Given bootstrap opssc-agents for initial orgs
 
     Then 2 chaincodes should be committed on ops-channel
@@ -109,3 +114,7 @@ Feature: Chaincode ops on docker-based Fabric network
     And the proposal status for chaincode (name: basic, seq: 3, channel: mychannel) should be rejected
     ## -- A proposal is not withdrawn after the decision
     Then org1 fails to withdraw the proposal for chaincode (name: basic, seq: 3, channel: mychannel) with an error (the voting is already closed)
+
+    # Chaincode update proposals rejected for a system or disable channel
+    Then org1 fails to request a proposal to deploy the chaincode (name: basic, seq: 1, channel: system-channel) based on basic golang template via opssc-api-server
+    Then org1 fails to request a proposal to deploy the chaincode (name: basic, seq: 1, channel: invalid-channel) based on basic golang template via opssc-api-server

--- a/integration/steps/fabric-network-deployment.steps.ts
+++ b/integration/steps/fabric-network-deployment.steps.ts
@@ -68,10 +68,15 @@ export class FabricNetworkDeploymentSteps extends BaseStepClass {
     execSync(commands);
   }
 
-  @given(/register orgs info for (.+) \(type: (system|application|ops)\) to opssc on (..+)/)
+  @given(/register orgs info for (.+) \(type: (system|application|ops)\) to opssc on (.+)/)
   public registerOrgInfo(newChannelName: string, newChannelType: string, opsChannelName: string) {
     const commands = `cd ${BaseStepClass.TEST_NETWORK_PATH} && ./registerNetworkInfoToOpsSC.sh ${opsChannelName} ${newChannelName} ${newChannelType}`;
     execSync(commands);
+  }
+
+  @given(/disable (.+) channel on opssc via opssc-api-server/)
+  public async disableChannel(channelName: string) {
+    await this.invokeChannelOpsFunc('UpdateChannelType', [channelName, 'disable']);
   }
 
   @given(/bootstrap opssc-api-servers for initial orgs/)

--- a/integration/utils/base-step-class.ts
+++ b/integration/utils/base-step-class.ts
@@ -6,6 +6,7 @@
 
 import { setDefaultTimeout } from 'cucumber';
 import moment from 'moment';
+import axios from 'axios';
 
 setDefaultTimeout(240 * 1000);
 
@@ -48,6 +49,8 @@ export default class BaseStepClass {
 
   protected static TEST_NETWORK_PATH = '../sample-environments/fabric-samples/test-network';
   protected static OPS_CHANNEL = 'ops-channel';
+  protected static CC_OPS_CC_NAME = 'chaincode_ops';
+  protected static CH_OPS_CC_NAME = 'channel_ops';
 
   protected static RETRY = 15;
   protected static SUFFIX = moment().format('MMDD_HHmmss');
@@ -69,5 +72,30 @@ export default class BaseStepClass {
 
   protected getAgentServiceEndpoint(org = 'org1') {
     return `http://localhost:${BaseStepClass.SERVICE_PORT_MAP[org].agent}`;
+  }
+
+  private async invokeOpsSCFunc(ccName: string, funcName: string, args: string[]): Promise<number> {
+    const response = await axios.post(`${this.getAPIEndpoint()}/api/v1/utils/invokeTransaction`,
+      {
+        channelID: BaseStepClass.OPS_CHANNEL,
+        ccName: ccName,
+        func: funcName,
+        args: args,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+    return response.status;
+  }
+
+  protected async invokeChaincodeOpsFunc(funcName: string, args: string[]): Promise<number> {
+    return this.invokeOpsSCFunc(BaseStepClass.CC_OPS_CC_NAME, funcName, args);
+  }
+
+  protected async invokeChannelOpsFunc(funcName: string, args: string[]): Promise<number> {
+    return this.invokeOpsSCFunc(BaseStepClass.CH_OPS_CC_NAME, funcName, args);
   }
 }

--- a/opssc-agent/src/bootstrap-operator.ts
+++ b/opssc-agent/src/bootstrap-operator.ts
@@ -116,9 +116,9 @@ export class BootstrapOperatorImpl implements BootstrapOperator {
 
     const channels = await this.getAllChannels();
     for (const targetChannelInfo of channels) {
-      logger.info(`Join my peers to ${targetChannelInfo.ID}`);
-      if (targetChannelInfo.channelType === 'system' || targetChannelInfo.channelType === 'ops') {
-        logger.info(`Skip channel ${targetChannelInfo.ID} (type: system or ops)`);
+      logger.info(`Join my peers to ${targetChannelInfo.ID} (type: ${targetChannelInfo.channelType})`);
+      if (targetChannelInfo.channelType !== 'application') {
+        logger.info(`Skip channel ${targetChannelInfo.ID} (type: ${targetChannelInfo.channelType})`);
         continue;
       }
       if (targetChannelInfo.organizations == null || !(this.mspID in targetChannelInfo.organizations)) {
@@ -218,8 +218,8 @@ export class BootstrapOperatorImpl implements BootstrapOperator {
 
     for (const targetChannelInfo of channels) {
 
-      if (targetChannelInfo.channelType === 'system') {
-        logger.info(`Skip channel ${targetChannelInfo.ID} (type: system)`);
+      if (targetChannelInfo.channelType === 'system' || targetChannelInfo.channelType === 'disable') {
+        logger.info(`Skip channel ${targetChannelInfo.ID} (type: ${targetChannelInfo.channelType})`);
         continue;
       }
       if (targetChannelInfo.organizations == null || !(this.mspID in targetChannelInfo.organizations)) {


### PR DESCRIPTION
This patch adds the following features:
- Add `updateChannelType()` for updating the channel type to channel_ops
- Introduce 'disable' channel type to exclude the channel from management by OpsSC
  - (1) Exclude bootstrap processing for the channel in agent
  - (2) Reject a chaincode update proposal for the channel
  - (3) Allow OpsSC to manage the workflow of the proposal that has already been submitted (to prevent the control from becoming complicated)