### PR TITLE
Add config options whether to enable some APIs

### DIFF
--- a/opssc-agent/src/config.ts
+++ b/opssc-agent/src/config.ts
@@ -50,11 +50,11 @@ export const config: OpsSCAgentConfig = {
     adminKey: readSingleFileOnThePath(process.env.ADMIN_KEY || '/opt/fabric/msp/admin.key'),
     adminCert: readSingleFileOnThePath(process.env.ADMIN_CERT || '/opt/fabric/msp/admin.crt'),
     connectionProfile: yaml.safeLoad(fs.readFileSync(process.env.CONNECTION_PROFILE || '/opt/fabric/config/connection-profile.yaml', 'utf8')) as Record<string, any>,
-    discoverAsLocalhost: process.env.DISCOVER_AS_LOCALHOST !== 'false',
+    discoverAsLocalhost: process.env.DISCOVER_AS_LOCALHOST === 'true',
   },
   ws: {
     websocketUrl: process.env.WS_URL || 'ws://localhost:5000',
-    enabled: process.env.WS_ENABLED !== 'false',
+    enabled: process.env.WS_ENABLED === 'true',
   },
   core: {
     opssc: {

--- a/opssc-api-server/README.md
+++ b/opssc-api-server/README.md
@@ -23,20 +23,21 @@ The current OpsSC API server is set via environment variables.
 
 The following environment variables must be set:
 
-| Category           | Variable Name           | Default Value                                | Description                                                                                             |
-| ------------------ | ----------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Hyperledger Fabric | `ADMIN_MSPID`           | `Org1MSP`                                    | MSP ID for the organization to be operated                                                              |
-| Hyperledger Fabric | `ADMIN_CERT`            | `/opt/fabric/msp/signcerts`                  | Certificate for the client identity to interact with the OpsSC chaincodes and execute peer commands     |
-| Hyperledger Fabric | `ADMIN_KEY`             | `/opt/fabric/msp/keystore`                   | Private key for the client identity to interact with the OpsSC chaincodes and execute peer commands     |
-| Hyperledger Fabric | `MSP_CONFIG_PATH`       | `/opt/fabric/msp`                            | MSP config path for the client identity to interact with the OpsSC chaincodes and execute peer commands |
-| Hyperledger Fabric | `DISCOVER_AS_LOCALHOST` | `false`                                      | Whether to discover as localhost                                                                        |
-| Hyperledger Fabric | `CONNECTION_PROFILE`    | `/opt/fabric/config/connection-profile.yaml` | Connection profile path for the organization                                                            |
-| OpsSC              | `CHANNEL_NAME`          | `ops-channel`                                | Channel name for the OpsSC                                                                              |
-| OpsSC              | `CC_OPS_CC_NAME`        | `chaincode_ops`                              | Chaincode name of the chaincode OpsSC                                                                   |
-| OpsSC              | `CH_OPS_CC_NAME`        | `channel_ops`                                | Chaincode name of the channel OpsSC                                                                     |
-| API Server         | `CLIENT_SERVICE_PORT`   | `5000`                                       | Port number used by the API server                                                                      |
-| Logging            | `LOG_LEVEL`             | `info`                                       | Log level                                                                                               |
-
+| Category           | Variable Name             | Default Value                                | Description                                                                                             |
+| ------------------ | ------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Hyperledger Fabric | `ADMIN_MSPID`             | `Org1MSP`                                    | MSP ID for the organization to be operated                                                              |
+| Hyperledger Fabric | `ADMIN_CERT`              | `/opt/fabric/msp/signcerts`                  | Certificate for the client identity to interact with the OpsSC chaincodes and execute peer commands     |
+| Hyperledger Fabric | `ADMIN_KEY`               | `/opt/fabric/msp/keystore`                   | Private key for the client identity to interact with the OpsSC chaincodes and execute peer commands     |
+| Hyperledger Fabric | `MSP_CONFIG_PATH`         | `/opt/fabric/msp`                            | MSP config path for the client identity to interact with the OpsSC chaincodes and execute peer commands |
+| Hyperledger Fabric | `DISCOVER_AS_LOCALHOST`   | `false`                                      | Whether to discover as localhost                                                                        |
+| Hyperledger Fabric | `CONNECTION_PROFILE`      | `/opt/fabric/config/connection-profile.yaml` | Connection profile path for the organization                                                            |
+| OpsSC              | `CHANNEL_NAME`            | `ops-channel`                                | Channel name for the OpsSC                                                                              |
+| OpsSC              | `CC_OPS_CC_NAME`          | `chaincode_ops`                              | Chaincode name of the chaincode OpsSC                                                                   |
+| OpsSC              | `CH_OPS_CC_NAME`          | `channel_ops`                                | Chaincode name of the channel OpsSC                                                                     |
+| API Server         | `CLIENT_SERVICE_PORT`     | `5000`                                       | Port number used by the API server                                                                      |
+| API Server         | `API_CH_PROPOSAL_ENABLED` | `true`                                       | Whether to enable the Channel Update Proposal APIs                                                      |
+| API Server         | `API_UTIL_ENABLED`        | `true`                                       | Whether to enable the Utility APIs                                                                      |
+| Logging            | `LOG_LEVEL`               | `info`                                       | Log level                                                                                               |
 
 ## API specification
 
@@ -74,6 +75,7 @@ The current OpsSC API server is expected to run primarily as a Docker container.
 ### Build the Docker image
 
 Build the docker image for API Server by running the following commands:
+
 ```sh
 $ cd fabric-opssc
 $ make docker-opssc-api-server

--- a/opssc-api-server/src/config.ts
+++ b/opssc-api-server/src/config.ts
@@ -10,9 +10,15 @@ import { FabricConfig } from 'opssc-common/fabric-client';
 import { OpsSCConfig } from 'opssc-common/config';
 import { readSingleFileOnThePath } from 'opssc-common/utils';
 
+export interface OpsSCAPIServerFeatureOption {
+  channelProposalAPIEnabled: boolean;
+  utilityAPIEnabled: boolean;
+}
+
 export interface OpsSCAPIServerConfig {
     fabric: FabricConfig;
     opsSC: OpsSCConfig;
+    featureOption: OpsSCAPIServerFeatureOption;
 }
 
 export const config: OpsSCAPIServerConfig = {
@@ -21,7 +27,7 @@ export const config: OpsSCAPIServerConfig = {
     adminKey: readSingleFileOnThePath(process.env.ADMIN_KEY || '/opt/fabric/msp/keystore'),
     adminMSPConfigPath: process.env.MSP_CONFIG_PATH || '/opt/fabric/msp',
     adminMSPID: process.env.ADMIN_MSPID || 'Org1MSP',
-    discoverAsLocalhost: process.env.DISCOVER_AS_LOCALHOST !== 'false',
+    discoverAsLocalhost: process.env.DISCOVER_AS_LOCALHOST === 'true',
     connectionProfile: yaml.safeLoad(fs.readFileSync(process.env.CONNECTION_PROFILE || '/opt/fabric/config/connection-profile.yaml', 'utf8')) as Record<string, any>,
   },
   opsSC: {
@@ -30,5 +36,9 @@ export const config: OpsSCAPIServerConfig = {
       chaincodeOpsCCName: process.env.CC_OPS_CC_NAME || 'chaincode_ops',
       channelOpsCCName: process.env.CH_OPS_CC_NAME || 'channel_ops',
     }
+  },
+  featureOption: {
+    channelProposalAPIEnabled: process.env.API_CH_PROPOSAL_ENABLED !== 'false',
+    utilityAPIEnabled: process.env.API_UTIL_ENABLED !== 'false',
   }
 };

--- a/opssc-api-server/src/index.ts
+++ b/opssc-api-server/src/index.ts
@@ -24,7 +24,7 @@ const _cors = cors();
 app.use(_cors);
 
 const fabricClient = new FabricClient(config.fabric);
-app.use('/api/v1', api(fabricClient, config.opsSC));
+app.use('/api/v1', api(fabricClient, config));
 
 app.get('/healthz', (_req, res) => {
   // TODO: More diagnosis

--- a/opssc-api-server/src/package-lock.json
+++ b/opssc-api-server/src/package-lock.json
@@ -1340,9 +1340,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -2756,8 +2756,7 @@
         },
         "follow-redirects": {
           "version": "1.14.6",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-          "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+          "resolved": ""
         },
         "forwarded": {
           "version": "0.1.2",

--- a/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org3.yaml
+++ b/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org3.yaml
@@ -22,6 +22,7 @@ services:
       - GIT_USER=$GIT_USER
       - GIT_PASSWORD=$GIT_PASSWORD
       - AGENT_SERVICE_PORT=5502
+      - WS_ENABLED=true
       - WS_URL=ws://opssc-api-server.org3.example.com:5002
     volumes:
       - ../organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp:/opt/fabric/msp

--- a/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org4.yaml
+++ b/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org4.yaml
@@ -22,6 +22,7 @@ services:
       - GIT_USER=$GIT_USER
       - GIT_PASSWORD=$GIT_PASSWORD
       - AGENT_SERVICE_PORT=5503
+      - WS_ENABLED=true
       - WS_URL=ws://opssc-api-server.org4.example.com:5003
     volumes:
       - ../organizations/peerOrganizations/org4.example.com/users/Admin@org4.example.com/msp:/opt/fabric/msp

--- a/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents.yaml
+++ b/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents.yaml
@@ -22,6 +22,7 @@ services:
       - GIT_USER=$GIT_USER
       - GIT_PASSWORD=$GIT_PASSWORD
       - AGENT_SERVICE_PORT=5500
+      - WS_ENABLED=true
       - WS_URL=ws://opssc-api-server.org1.example.com:5000
     volumes:
       - ../organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp:/opt/fabric/msp
@@ -43,6 +44,7 @@ services:
       - GIT_USER=$GIT_USER
       - GIT_PASSWORD=$GIT_PASSWORD
       - AGENT_SERVICE_PORT=5501
+      - WS_ENABLED=true
       - WS_URL=ws://opssc-api-server.org2.example.com:5001
     volumes:
       - ../organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp:/opt/fabric/msp

--- a/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-api-servers-org3.yaml
+++ b/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-api-servers-org3.yaml
@@ -18,6 +18,8 @@ services:
       - LOG_LEVEL=info
       - DISCOVER_AS_LOCALHOST=false
       - CLIENT_SERVICE_PORT=5002
+      - API_CH_PROPOSAL_ENABLED=true
+      - API_UTIL_ENABLED=true
     volumes:
       - ../organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp:/opt/fabric/msp
       - ../organizations/peerOrganizations/org3.example.com/connection-org3.yaml:/opt/fabric/config/connection-profile.yaml

--- a/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-api-servers-org4.yaml
+++ b/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-api-servers-org4.yaml
@@ -18,6 +18,8 @@ services:
       - LOG_LEVEL=info
       - DISCOVER_AS_LOCALHOST=false
       - CLIENT_SERVICE_PORT=5003
+      - API_CH_PROPOSAL_ENABLED=true
+      - API_UTIL_ENABLED=true
     volumes:
       - ../organizations/peerOrganizations/org4.example.com/users/Admin@org4.example.com/msp:/opt/fabric/msp
       - ../organizations/peerOrganizations/org4.example.com/connection-org4.yaml:/opt/fabric/config/connection-profile.yaml

--- a/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-api-servers.yaml
+++ b/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-api-servers.yaml
@@ -18,6 +18,8 @@ services:
       - LOG_LEVEL=info
       - DISCOVER_AS_LOCALHOST=false
       - CLIENT_SERVICE_PORT=5000
+      - API_CH_PROPOSAL_ENABLED=true
+      - API_UTIL_ENABLED=true
     volumes:
       - ../organizations/peerOrganizations/org1.example.com/connection-org1.yaml:/opt/fabric/config/connection-profile.yaml
       - ../organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp:/opt/fabric/msp
@@ -34,6 +36,8 @@ services:
       - LOG_LEVEL=info
       - DISCOVER_AS_LOCALHOST=false
       - CLIENT_SERVICE_PORT=5001
+      - API_CH_PROPOSAL_ENABLED=true
+      - API_UTIL_ENABLED=true
     volumes:
       - ../organizations/peerOrganizations/org2.example.com/connection-org2.yaml:/opt/fabric/config/connection-profile.yaml
       - ../organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp:/opt/fabric/msp


### PR DESCRIPTION
This patch adds the following options whether to enable APIs:
- API_CH_PROPOSAL_ENABLED: Whether to enable the Channel Update Proposal APIs
- API_UTIL_ENABLED: Whether to enable the Utility APIs

NOTE: This option only controls at the API server layer. Note that direct execution of the chaincode is still allowed.

This also includes some minor fixes for the default values of some config options.