### PR TITLE
Add tests catching up on events during an agent stop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 Hitachi, Ltd. All Rights Reserved.
+# Copyright 2021-2022 Hitachi, Ltd. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -19,7 +19,7 @@ FABRIC_TWO_DIGIT_VERSION ?= 2.4
 SUPPORT_FABRIC_TWO_DIGIT_VERSIONS = 2.4 2.2
 
 .PHONY: build-and-tests-all
-build-and-tests-all: $(SUPPORT_FABRIC_TWO_DIGIT_VERSIONS:%=docker-opssc-agent/%) $(SUPPORT_FABRIC_TWO_DIGIT_VERSIONS:%=docker-opssc-api-server/%) $(SUPPORT_FABRIC_TWO_DIGIT_VERSIONS:%=integration-test/%)
+build-and-tests-all: lint $(SUPPORT_FABRIC_TWO_DIGIT_VERSIONS:%=docker-opssc-agent/%) $(SUPPORT_FABRIC_TWO_DIGIT_VERSIONS:%=docker-opssc-api-server/%) $(SUPPORT_FABRIC_TWO_DIGIT_VERSIONS:%=integration-test/%)
 
 .PHONY: build-and-tests
 build-and-tests: lint $(FABRIC_TWO_DIGIT_VERSION:%=docker-opssc-agent/%) $(FABRIC_TWO_DIGIT_VERSION:%=docker-opssc-api-server/%) $(FABRIC_TWO_DIGIT_VERSION:%=integration-test/%)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The main reason for using two languages is that the Fabric SDK Go is not yet GA 
 
 The current implementation assumes the following Fabric network:
 
-- Hyperledger Fabric v2.4.0 or later (Tested by using v2.4.2)
+- Hyperledger Fabric v2.4.0 or later (Tested by using v2.4.3)
   - Also it works in v2.2.2 or later (Tested by using v2.2.5)
 - Fabric network configuration
   - Using Fabric CAs
@@ -151,7 +151,7 @@ By running the following commands, download the binaries and docker images for H
 
 ```sh
 $ cd ${FABRIC_OPSSC}/sample-environments/fabric-samples
-$ export FABRIC_VERSION=2.4.2
+$ export FABRIC_VERSION=2.4.3
 $ export FABRIC_CA_VERSION=1.5.2
 $ curl -sSL https://bit.ly/2ysbOFE | bash -s -- ${FABRIC_VERSION} ${FABRIC_CA_VERSION} -s
 

--- a/integration/steps/fabric-network-deployment.steps.ts
+++ b/integration/steps/fabric-network-deployment.steps.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
+ * Copyright 2020-2022 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -27,7 +27,7 @@ export class FabricNetworkDeploymentSteps extends BaseStepClass {
   }
 
   private cleanupFabricNetwork() {
-    let commands = `docker-compose -f ${BaseStepClass.TEST_NETWORK_PATH}/docker/docker-compose-opssc-agents.yaml -f ${BaseStepClass.TEST_NETWORK_PATH}/docker/docker-compose-opssc-agents-org3.yaml -f ${BaseStepClass.TEST_NETWORK_PATH}/docker/docker-compose-opssc-agents-org4.yaml down --remove-orphans`;
+    let commands = `docker-compose -f ${BaseStepClass.TEST_NETWORK_PATH}/docker/docker-compose-opssc-agents.yaml -f ${BaseStepClass.TEST_NETWORK_PATH}/docker/docker-compose-opssc-agents-org3.yaml -f ${BaseStepClass.TEST_NETWORK_PATH}/docker/docker-compose-opssc-agents-org4.yaml down --volumes --remove-orphans`;
     execSync(commands);
 
     commands = `docker-compose -f ${BaseStepClass.TEST_NETWORK_PATH}/docker/docker-compose-opssc-api-servers.yaml -f ${BaseStepClass.TEST_NETWORK_PATH}/docker/docker-compose-opssc-api-servers-org3.yaml -f ${BaseStepClass.TEST_NETWORK_PATH}/docker/docker-compose-opssc-api-servers-org4.yaml down --remove-orphans`;

--- a/integration/teardownDockerEnv.sh
+++ b/integration/teardownDockerEnv.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# Copyright 2020 Hitachi America, Ltd. All Rights Reserved.
+# Copyright 2020-2022 Hitachi, Ltd. Hitachi America, Ltd. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
-docker-compose -f ../sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents.yaml  -f ../sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org3.yaml -f ../sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org4.yaml down --remove-orphans
+docker-compose -f ../sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents.yaml  -f ../sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org3.yaml -f ../sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org4.yaml down --volumes --remove-orphans
 docker-compose -f ../sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-api-servers.yaml -f ../sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-api-servers-org3.yaml -f ../sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-api-servers-org4.yaml down --remove-orphans
 
 cd ../sample-environments/fabric-samples/test-network && ./network.sh down

--- a/integration/utils/base-step-class.ts
+++ b/integration/utils/base-step-class.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
+ * Copyright 2020-2022 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,7 +30,7 @@ export default class BaseStepClass {
   protected static FABRIC_TWO_DIGIT_VERSION = process.env.FABRIC_TWO_DIGIT_VERSION ? process.env.FABRIC_TWO_DIGIT_VERSION : '2.4';
 
   protected static FABRIC_VERSION_MAP: { [char: string]: FabricVersion } = {
-    '2.4': { fabric: '2.4.2', fabricCA: '1.5.2' },
+    '2.4': { fabric: '2.4.3', fabricCA: '1.5.2' },
     '2.2': { fabric: '2.2.5', fabricCA: '1.5.2' },
   }
 

--- a/opssc-agent/scripts/build.sh
+++ b/opssc-agent/scripts/build.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Copyright 2019-2021 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
+# Copyright 2019-2022 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -18,7 +18,7 @@ FABRIC_TWO_DIGIT_VERSION=$2
 if [ "${FABRIC_TWO_DIGIT_VERSION}" = "2.2" ]; then
   FABRIC_VERSION=2.2.5
 else
-  FABRIC_VERSION=2.4.2
+  FABRIC_VERSION=2.4.3
   FABRIC_TWO_DIGIT_VERSION=2.4
 fi
 

--- a/opssc-api-server/scripts/build.sh
+++ b/opssc-api-server/scripts/build.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Copyright 2019-2021 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
+# Copyright 2019-2022 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -18,7 +18,7 @@ FABRIC_TWO_DIGIT_VERSION=$2
 if [ "${FABRIC_TWO_DIGIT_VERSION}" = "2.2" ]; then
   FABRIC_VERSION=2.2.5
 else
-  FABRIC_VERSION=2.4.2
+  FABRIC_VERSION=2.4.3
   FABRIC_TWO_DIGIT_VERSION=2.4
 fi
 

--- a/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org3.yaml
+++ b/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org3.yaml
@@ -1,8 +1,11 @@
-# Copyright 2019-2021 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
+# Copyright 2019-2022 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-version: '2'
+version: "2"
+
+volumes:
+  opssc-agent.org3.example.com:
 
 networks:
   test:
@@ -27,6 +30,7 @@ services:
     volumes:
       - ../organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp:/opt/fabric/msp
       - ../organizations/peerOrganizations/org3.example.com/connection-org3.yaml:/opt/fabric/config/connection-profile.yaml
+      - opssc-agent.org3.example.com:/opt/opssc/data
     networks:
       - test
     ports:

--- a/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org4.yaml
+++ b/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents-org4.yaml
@@ -1,8 +1,11 @@
-# Copyright 2019-2021 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
+# Copyright 2019-2022 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-version: '2'
+version: "2"
+
+volumes:
+  opssc-agent.org4.example.com:
 
 networks:
   test:
@@ -27,6 +30,7 @@ services:
     volumes:
       - ../organizations/peerOrganizations/org4.example.com/users/Admin@org4.example.com/msp:/opt/fabric/msp
       - ../organizations/peerOrganizations/org4.example.com/connection-org4.yaml:/opt/fabric/config/connection-profile.yaml
+      - opssc-agent.org4.example.com:/opt/opssc/data
     networks:
       - test
     ports:

--- a/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents.yaml
+++ b/sample-environments/fabric-samples/test-network/docker/docker-compose-opssc-agents.yaml
@@ -1,8 +1,12 @@
-# Copyright 2019-2021 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
+# Copyright 2019-2022 Hitachi, Ltd., Hitachi America, Ltd. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-version: '2'
+version: "2"
+
+volumes:
+  opssc-agent.org1.example.com:
+  opssc-agent.org2.example.com:
 
 networks:
   test:
@@ -27,6 +31,7 @@ services:
     volumes:
       - ../organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp:/opt/fabric/msp
       - ../organizations/peerOrganizations/org1.example.com/connection-org1.yaml:/opt/fabric/config/connection-profile.yaml
+      - opssc-agent.org1.example.com:/opt/opssc/data
     networks:
       - test
     ports:
@@ -49,6 +54,7 @@ services:
     volumes:
       - ../organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp:/opt/fabric/msp
       - ../organizations/peerOrganizations/org2.example.com/connection-org2.yaml:/opt/fabric/config/connection-profile.yaml
+      - opssc-agent.org2.example.com:/opt/opssc/data
     networks:
       - test
     ports:


### PR DESCRIPTION
This patch adds tests catching up on events during an agent stop.
Also, this bumps the fabric version to v2.4.2.