### PR TITLE
docs(*): Add maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,8 @@
+# Maintainers
+
+## Active Maintainers
+
+| Name           | GitHub                                 | Discord      |
+|----------------|----------------------------------------|--------------|
+| Tatsuya Sato   | [@satota2](https://github.com/satota2) | satota2#5505 |
+| Taku Shimosawa | [@shimos](https://github.com/shimos)   | shimos#2760  |


### PR DESCRIPTION
This patch adds the list of the maintainers of this repository.

Resolves #53 

Signed-off-by: Taku Shimosawa <taku.shimosawa.uf@hitachi.com>